### PR TITLE
Remove getopt.h dependency

### DIFF
--- a/src/archive/archive.cpp
+++ b/src/archive/archive.cpp
@@ -29,13 +29,13 @@ int main(int argc, const char **argv) {
     options.emplace_back("tags", 't', 1);
     options.emplace_back("output", 'o', 1);
 
-    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<ArchiveOptions &>(argc, argv, options, 'h', archive_options, [](char opt, const auto &args, auto &archive_options) {
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<ArchiveOptions &>(argc, argv, options, 'h', archive_options, [](char opt, const auto &arguments, auto &archive_options) {
         switch(opt) {
             case 't':
-                archive_options.tags.push_back(optarg);
+                archive_options.tags.push_back(arguments[0]);
                 break;
             case 'o':
-                archive_options.output = optarg;
+                archive_options.output = arguments[0];
                 break;
             case 'i':
                 INVADER_SHOW_INFO

--- a/src/bitmap/bitmap.cpp
+++ b/src/bitmap/bitmap.cpp
@@ -322,8 +322,12 @@ int main(int argc, char *argv[]) {
     });
 
     // Make sure we have the bitmap tag path
-    if(optind != argc - 1) {
-        eprintf("%s: Expected a bitmap tag path. Use -h for help.\n", argv[0]);
+    if(remaining_arguments.size() == 0) {
+        eprintf("Expected a bitmap tag path. Use -h for help.\n");
+        return EXIT_FAILURE;
+    }
+    else if(remaining_arguments.size() > 1) {
+        eprintf("Unexpected argument %s\n", remaining_arguments[1]);
         return EXIT_FAILURE;
     }
     std::string bitmap_tag = argv[argc - 1];

--- a/src/bitmap/bitmap.cpp
+++ b/src/bitmap/bitmap.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#include <getopt.h>
 #include <zlib.h>
 #include <filesystem>
 #include <optional>
@@ -11,6 +10,7 @@
 #include "image_loader.hpp"
 #include "color_plate_scanner.hpp"
 #include "bitmap_data_writer.hpp"
+#include "../command_line_option.hpp"
 
 enum SUPPORTED_FORMATS_INT {
     SUPPORTED_FORMATS_TIF = 0,
@@ -35,237 +35,238 @@ static_assert(sizeof(SUPPORTED_FORMATS) / sizeof(*SUPPORTED_FORMATS) == SUPPORTE
 int main(int argc, char *argv[]) {
     using namespace Invader::HEK;
     using namespace Invader;
-    int opt;
 
-    // Data directory
-    const char *data = "data/";
+    struct BitmapOptions {
+        // Program path
+        const char *path;
 
-    // Tags directory
-    const char *tags = "tags/";
+        // Data directory
+        const char *data = "data/";
 
-    // Scale type?
-    std::optional<ScannedColorMipmapType> mipmap_scale_type;
+        // Tags directory
+        const char *tags = "tags/";
 
-    // Format?
-    std::optional<BitmapFormat> format;
+        // Scale type?
+        std::optional<ScannedColorMipmapType> mipmap_scale_type;
 
-    // Usage?
-    std::optional<BitmapUsage> usage;
+        // Format?
+        std::optional<BitmapFormat> format;
 
-    // Bump stuff
-    std::optional<float> bump_height;
+        // Usage?
+        std::optional<BitmapUsage> usage;
 
-    // Palettize to p8 bump?
-    std::optional<bool> palettize;
+        // Bump stuff
+        std::optional<float> bump_height;
 
-    // Mipmap fade factor
-    std::optional<float> mipmap_fade;
+        // Palettize to p8 bump?
+        std::optional<bool> palettize;
 
-    // Bitmap type
-    std::optional<BitmapType> bitmap_type;
+        // Mipmap fade factor
+        std::optional<float> mipmap_fade;
 
-    // Sprite parameters
-    std::optional<BitmapSpriteUsage> sprite_usage;
-    std::optional<std::uint32_t> sprite_budget;
-    std::optional<std::uint32_t> sprite_budget_count;
+        // Bitmap type
+        std::optional<BitmapType> bitmap_type;
 
-    // Dithering?
-    std::optional<bool> dither_alpha, dither_red, dither_green, dither_blue;
-    bool dithering = false;
+        // Sprite parameters
+        std::optional<BitmapSpriteUsage> sprite_usage;
+        std::optional<std::uint32_t> sprite_budget;
+        std::optional<std::uint32_t> sprite_budget_count;
 
-    // Sharpen and blur; legacy support for older tags and should not be used in newer ones
-    std::optional<float> sharpen;
-    std::optional<float> blur;
+        // Dithering?
+        std::optional<bool> dither_alpha, dither_red, dither_green, dither_blue;
+        bool dithering = false;
 
-    // Generate this many mipmaps
-    std::optional<std::uint16_t> max_mipmap_count;
+        // Sharpen and blur; legacy support for older tags and should not be used in newer ones
+        std::optional<float> sharpen;
+        std::optional<float> blur;
 
-    // Ignore the tag data?
-    bool ignore_tag_data = false;
+        // Generate this many mipmaps
+        std::optional<std::uint16_t> max_mipmap_count;
 
-    // Long options
-    int longindex = 0;
-    static struct option options[] = {
-        {"info",  no_argument, 0, 'i'},
-        {"ignore-tag",  no_argument, 0, 'I'},
-        {"help",  no_argument, 0, 'h'},
-        {"dithering",  required_argument, 0, 'D'},
-        {"data",  required_argument, 0, 'd' },
-        {"tags",  required_argument, 0, 't' },
-        {"format", required_argument, 0, 'F' },
-        {"type", required_argument, 0, 'T' },
-        {"mipmap-count", required_argument, 0, 'm' },
-        {"mipmap-scale", required_argument, 0, 's' },
-        {"detail-fade", required_argument, 0, 'f' },
-        {"budget", required_argument, 0, 'B' },
-        {"budget-count", required_argument, 0, 'C' },
-        {"bump-palettize", required_argument, 0, 'p' },
-        {"bump-palettise", required_argument, 0, 'p' },
-        {"bump-height", required_argument, 0, 'H' },
-        {0, 0, 0, 0 }
-    };
+        // Ignore the tag data?
+        bool ignore_tag_data = false;
+    } bitmap_options;
+    bitmap_options.path = argv[0];
+
+    std::vector<CommandLineOption> options;
+    options.emplace_back("info", 'i', 0);
+    options.emplace_back("ignore-tag", 'I', 0);
+    options.emplace_back("help", 'h', 0);
+    options.emplace_back("dithering", 'D', 1);
+    options.emplace_back("data", 'd', 1);
+    options.emplace_back("tags", 't', 1);
+    options.emplace_back("format", 'F', 1);
+    options.emplace_back("type", 'T', 1);
+    options.emplace_back("mipmap-count", 'm', 1);
+    options.emplace_back("mipmap-scale", 's', 1);
+    options.emplace_back("detail-fade", 'f', 1);
+    options.emplace_back("budget", 'B', 1);
+    options.emplace_back("budget-count", 'C', 1);
+    options.emplace_back("bump-palettize", 'p', 1);
+    options.emplace_back("bump-palettise", 'p', 1);
+    options.emplace_back("bump-height", 'H', 1);
 
     // Go through each argument
-    while((opt = getopt_long(argc, argv, "D:iIhd:t:f:s:f:F:m:T:B:C:p:h:u:H:", options, &longindex)) != -1) {
+    auto remaining_arguments = CommandLineOption::parse_arguments<BitmapOptions &>(argc, argv, options, 'h', bitmap_options, [](char opt, const std::vector<const char *> &arguments, BitmapOptions &bitmap_options) {
         switch(opt) {
             case 'd':
-                data = optarg;
+                bitmap_options.data = arguments[0];
                 break;
 
             case 't':
-                tags = optarg;
+                bitmap_options.tags = arguments[0];
                 break;
 
             case 'i':
                 INVADER_SHOW_INFO
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
 
             case 'I':
-                ignore_tag_data = true;
+                bitmap_options.ignore_tag_data = true;
                 break;
 
             case 'f':
-                mipmap_fade = std::strtof(optarg, nullptr);
-                if(mipmap_fade < 0.0F || mipmap_fade > 1.0F) {
+                bitmap_options.mipmap_fade = std::strtof(arguments[0], nullptr);
+                if(bitmap_options.mipmap_fade < 0.0F || bitmap_options.mipmap_fade > 1.0F) {
                     eprintf("Mipmap fade must be between 0-1\n");
-                    return EXIT_FAILURE;
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 's':
-                if(std::strcmp(optarg, "linear") == 0) {
-                    mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR;
+                if(std::strcmp(arguments[0], "linear") == 0) {
+                    bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR;
                 }
-                else if(std::strcmp(optarg, "nearest") == 0) {
-                    mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA_COLOR;
+                else if(std::strcmp(arguments[0], "nearest") == 0) {
+                    bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA_COLOR;
                 }
-                else if(std::strcmp(optarg, "nearest-alpha") == 0) {
-                    mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA;
+                else if(std::strcmp(arguments[0], "nearest-alpha") == 0) {
+                    bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA;
                 }
                 else {
-                    eprintf("Unknown mipmap scale type %s\n", optarg);
-                    return EXIT_FAILURE;
+                    eprintf("Unknown mipmap scale type %s\n", arguments[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 'F':
-                if(std::strcmp(optarg, "32-bit") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_32_BIT_COLOR;
+                if(std::strcmp(arguments[0], "32-bit") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_32_BIT_COLOR;
                 }
-                else if(std::strcmp(optarg, "16-bit") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_16_BIT_COLOR;
+                else if(std::strcmp(arguments[0], "16-bit") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_16_BIT_COLOR;
                 }
-                else if(std::strcmp(optarg, "monochrome") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_MONOCHROME;
+                else if(std::strcmp(arguments[0], "monochrome") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_MONOCHROME;
                 }
-                else if(std::strcmp(optarg, "dxt5") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_INTERPOLATED_ALPHA;
+                else if(std::strcmp(arguments[0], "dxt5") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_INTERPOLATED_ALPHA;
                 }
-                else if(std::strcmp(optarg, "dxt3") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_EXPLICIT_ALPHA;
+                else if(std::strcmp(arguments[0], "dxt3") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_EXPLICIT_ALPHA;
                 }
-                else if(std::strcmp(optarg, "dxt1") == 0) {
-                    format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_COLOR_KEY_TRANSPARENCY;
+                else if(std::strcmp(arguments[0], "dxt1") == 0) {
+                    bitmap_options.format = BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_COLOR_KEY_TRANSPARENCY;
                 }
                 else {
-                    eprintf("Unknown format %s\n", optarg);
-                    return EXIT_FAILURE;
+                    eprintf("Unknown format %s\n", arguments[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 'T':
-                if(std::strcmp(optarg, "2d") == 0) {
-                    bitmap_type = BitmapType::BITMAP_TYPE_2D_TEXTURES;
+                if(std::strcmp(arguments[0], "2d") == 0) {
+                    bitmap_options.bitmap_type = BitmapType::BITMAP_TYPE_2D_TEXTURES;
                 }
-                else if(std::strcmp(optarg, "3d") == 0) {
-                    bitmap_type = BitmapType::BITMAP_TYPE_3D_TEXTURES;
+                else if(std::strcmp(arguments[0], "3d") == 0) {
+                    bitmap_options.bitmap_type = BitmapType::BITMAP_TYPE_3D_TEXTURES;
                 }
-                else if(std::strcmp(optarg, "cubemap") == 0) {
-                    bitmap_type = BitmapType::BITMAP_TYPE_CUBE_MAPS;
+                else if(std::strcmp(arguments[0], "cubemap") == 0) {
+                    bitmap_options.bitmap_type = BitmapType::BITMAP_TYPE_CUBE_MAPS;
                 }
-                else if(std::strcmp(optarg, "interface") == 0) {
-                    bitmap_type = BitmapType::BITMAP_TYPE_INTERFACE_BITMAPS;
+                else if(std::strcmp(arguments[0], "interface") == 0) {
+                    bitmap_options.bitmap_type = BitmapType::BITMAP_TYPE_INTERFACE_BITMAPS;
                 }
-                else if(std::strcmp(optarg, "sprite") == 0) {
-                    bitmap_type = BitmapType::BITMAP_TYPE_SPRITES;
+                else if(std::strcmp(arguments[0], "sprite") == 0) {
+                    bitmap_options.bitmap_type = BitmapType::BITMAP_TYPE_SPRITES;
                 }
                 else {
-                    eprintf("Unknown type %s\n", optarg);
-                    return EXIT_FAILURE;
+                    eprintf("Unknown type %s\n", arguments[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 'D':
-                dithering = true;
-                dither_alpha = false;
-                dither_red = false;
-                dither_green = false;
-                dither_blue = false;
-                for(const char *c = optarg; *c; c++) {
+                bitmap_options.dithering = true;
+                bitmap_options.dither_alpha = false;
+                bitmap_options.dither_red = false;
+                bitmap_options.dither_green = false;
+                bitmap_options.dither_blue = false;
+                for(const char *c = arguments[0]; *c; c++) {
                     switch(*c) {
                         case 'a':
-                            dither_alpha = true;
+                            bitmap_options.dither_alpha = true;
                             break;
                         case 'r':
-                            dither_red = true;
+                            bitmap_options.dither_red = true;
                             break;
                         case 'g':
-                            dither_green = true;
+                            bitmap_options.dither_green = true;
                             break;
                         case 'b':
-                            dither_blue = true;
+                            bitmap_options.dither_blue = true;
                             break;
                         default:
                             printf("Unknown channel %c.\n", *c);
-                            return EXIT_FAILURE;
+                            std::exit(EXIT_FAILURE);
                     }
                 }
                 break;
 
             case 'p':
-                if(strcmp(optarg,"on") == 0) {
-                    palettize = true;
+                if(strcmp(arguments[0],"on") == 0) {
+                    bitmap_options.palettize = true;
                 }
-                else if(strcmp(optarg,"off") == 0) {
-                    palettize = false;
+                else if(strcmp(arguments[0],"off") == 0) {
+                    bitmap_options.palettize = false;
                 }
                 else {
-                    eprintf("Unknown palettize setting %s\n", optarg);
-                    return EXIT_FAILURE;
+                    eprintf("Unknown palettize setting %s\n", arguments[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 'u':
-                if(strcmp(optarg, "default") == 0) {
-                    usage = BitmapUsage::BITMAP_USAGE_DEFAULT;
+                if(strcmp(arguments[0], "default") == 0) {
+                    bitmap_options.usage = BitmapUsage::BITMAP_USAGE_DEFAULT;
                 }
-                else if(strcmp(optarg, "bumpmap") == 0) {
-                    usage = BitmapUsage::BITMAP_USAGE_HEIGHT_MAP;
+                else if(strcmp(arguments[0], "bumpmap") == 0) {
+                    bitmap_options.usage = BitmapUsage::BITMAP_USAGE_HEIGHT_MAP;
                 }
-                else if(strcmp(optarg, "detail") == 0) {
-                    usage = BitmapUsage::BITMAP_USAGE_DETAIL_MAP;
+                else if(strcmp(arguments[0], "detail") == 0) {
+                    bitmap_options.usage = BitmapUsage::BITMAP_USAGE_DETAIL_MAP;
                 }
                 else {
-                    eprintf("Unknown usage %s\n", optarg);
-                    return EXIT_FAILURE;
+                    eprintf("Unknown usage %s\n", arguments[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             case 'H':
-                bump_height = static_cast<float>(std::strtof(optarg, nullptr));
+                bitmap_options.bump_height = static_cast<float>(std::strtof(arguments[0], nullptr));
                 break;
 
             case 'm':
-                max_mipmap_count = static_cast<std::int32_t>(std::strtol(optarg, nullptr, 10));
+                bitmap_options.max_mipmap_count = static_cast<std::int32_t>(std::strtol(arguments[0], nullptr, 10));
                 break;
 
             case 'C':
-                sprite_budget_count = static_cast<std::uint32_t>(std::strtoul(optarg, nullptr, 10));
+                bitmap_options.sprite_budget_count = static_cast<std::uint32_t>(std::strtoul(arguments[0], nullptr, 10));
                 break;
 
             case 'B':
-                sprite_budget = static_cast<std::uint32_t>(std::strtoul(optarg, nullptr, 10));
-                switch(sprite_budget.value()) {
+                bitmap_options.sprite_budget = static_cast<std::uint32_t>(std::strtoul(arguments[0], nullptr, 10));
+                switch(bitmap_options.sprite_budget.value()) {
                     case 32:
                     case 64:
                     case 128:
@@ -273,14 +274,14 @@ int main(int argc, char *argv[]) {
                     case 512:
                         break;
                     default:
-                        eprintf("Invalid sprite budget %u.\n", sprite_budget.value());
-                        return EXIT_FAILURE;
+                        eprintf("Invalid sprite budget %u.\n", bitmap_options.sprite_budget.value());
+                        std::exit(EXIT_FAILURE);
                 }
 
                 break;
 
             default:
-                eprintf("Usage: %s [options] <bitmap-tag>\n\n", *argv);
+                eprintf("Usage: %s [options] <bitmap-tag>\n\n", bitmap_options.path);
                 eprintf("Create or modify a bitmap tag.\n\n");
                 eprintf("Options:\n");
                 eprintf("    --info,-i                  Show license and credits.\n");
@@ -316,9 +317,9 @@ int main(int argc, char *argv[]) {
                 eprintf("    --budget,-B <length>       Set max length of sprite sheet. Can be 32, 64,\n");
                 eprintf("                               128, 256, or 512. Default (new tag): 32\n\n");
 
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
         }
-    }
+    });
 
     // Make sure we have the bitmap tag path
     if(optind != argc - 1) {
@@ -335,16 +336,16 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    std::filesystem::path data_path = data;
+    std::filesystem::path data_path = bitmap_options.data;
 
     // Get the path
-    std::filesystem::path tags_path(tags);
+    std::filesystem::path tags_path(bitmap_options.tags);
     auto tag_path = tags_path / bitmap_tag;
     auto final_path = tag_path.string() + ".bitmap";
 
     // See if we can get anything out of this
     std::FILE *tag_read;
-    if(!ignore_tag_data && (tag_read = std::fopen(final_path.data(), "rb"))) {
+    if(!bitmap_options.ignore_tag_data && (tag_read = std::fopen(final_path.data(), "rb"))) {
         // Here's in case we do fail. It cleans up and exits.
         auto exit_on_failure = [&tag_read, &final_path]() {
             eprintf("%s could not be read.\n", final_path.data());
@@ -371,66 +372,66 @@ int main(int argc, char *argv[]) {
         }
 
         // Set some default values
-        if(!format.has_value()) {
-            format = bitmap_tag_header.format;
+        if(!bitmap_options.format.has_value()) {
+            bitmap_options.format = bitmap_tag_header.format;
         }
-        if(!mipmap_fade.has_value()) {
-            mipmap_fade = bitmap_tag_header.detail_fade_factor;
+        if(!bitmap_options.mipmap_fade.has_value()) {
+            bitmap_options.mipmap_fade = bitmap_tag_header.detail_fade_factor;
         }
-        if(!bitmap_type.has_value()) {
-            bitmap_type = bitmap_tag_header.type;
+        if(!bitmap_options.bitmap_type.has_value()) {
+            bitmap_options.bitmap_type = bitmap_tag_header.type;
         }
-        if(!max_mipmap_count.has_value()) {
+        if(!bitmap_options.max_mipmap_count.has_value()) {
             std::int16_t mipmap_count = bitmap_tag_header.mipmap_count.read();
             if(mipmap_count == 0) {
-                max_mipmap_count = INT16_MAX;
+                bitmap_options.max_mipmap_count = INT16_MAX;
             }
             else {
-                max_mipmap_count = mipmap_count - 1;
+                bitmap_options.max_mipmap_count = mipmap_count - 1;
             }
         }
-        if(!sprite_usage.has_value()) {
-            sprite_usage = bitmap_tag_header.sprite_usage;
+        if(!bitmap_options.sprite_usage.has_value()) {
+            bitmap_options.sprite_usage = bitmap_tag_header.sprite_usage;
         }
-        if(!sprite_budget.has_value()) {
-            sprite_budget = 32 << bitmap_tag_header.sprite_budget_size;
+        if(!bitmap_options.sprite_budget.has_value()) {
+            bitmap_options.sprite_budget = 32 << bitmap_tag_header.sprite_budget_size;
         }
-        if(!sprite_budget_count.has_value()) {
-            sprite_budget_count = bitmap_tag_header.sprite_budget_count;
+        if(!bitmap_options.sprite_budget_count.has_value()) {
+            bitmap_options.sprite_budget_count = bitmap_tag_header.sprite_budget_count;
         }
-        if(!usage.has_value()) {
-            usage = bitmap_tag_header.usage;
+        if(!bitmap_options.usage.has_value()) {
+            bitmap_options.usage = bitmap_tag_header.usage;
         }
-        if(!palettize.has_value()) {
-            palettize = !bitmap_tag_header.flags.read().disable_height_map_compression;
+        if(!bitmap_options.palettize.has_value()) {
+            bitmap_options.palettize = !bitmap_tag_header.flags.read().disable_height_map_compression;
         }
-        if(!bump_height.has_value()) {
-            bump_height = bitmap_tag_header.bump_height;
+        if(!bitmap_options.bump_height.has_value()) {
+            bitmap_options.bump_height = bitmap_tag_header.bump_height;
         }
-        if(!sharpen.has_value() && bitmap_tag_header.sharpen_amount > 0.0F && bitmap_tag_header.sharpen_amount <= 1.0F) {
-            sharpen = bitmap_tag_header.sharpen_amount;
+        if(!bitmap_options.sharpen.has_value() && bitmap_tag_header.sharpen_amount > 0.0F && bitmap_tag_header.sharpen_amount <= 1.0F) {
+            bitmap_options.sharpen = bitmap_tag_header.sharpen_amount;
         }
-        if(!blur.has_value() && bitmap_tag_header.blur_filter_size > 0.0F) {
-            blur = bitmap_tag_header.blur_filter_size;
+        if(!bitmap_options.blur.has_value() && bitmap_tag_header.blur_filter_size > 0.0F) {
+            bitmap_options.blur = bitmap_tag_header.blur_filter_size;
         }
 
         auto header_flags = bitmap_tag_header.flags.read();
-        if(!mipmap_scale_type.has_value()) {
+        if(!bitmap_options.mipmap_scale_type.has_value()) {
             if(header_flags.invader_nearest_mipmap_alpha_and_color) {
-                mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA_COLOR;
+                bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA_COLOR;
             }
             else if(header_flags.invader_nearest_mipmap_alpha) {
-                mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA;
+                bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA;
             }
             else {
-                mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR;
+                bitmap_options.mipmap_scale_type = ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR;
             }
         }
-        if(!dithering) {
-            dither_alpha = header_flags.invader_dither_alpha == 1;
-            dither_red = header_flags.invader_dither_red == 1;
-            dither_green = header_flags.invader_dither_green == 1;
-            dither_blue = header_flags.invader_dither_blue == 1;
+        if(!bitmap_options.dithering) {
+            bitmap_options.dither_alpha = header_flags.invader_dither_alpha == 1;
+            bitmap_options.dither_red = header_flags.invader_dither_red == 1;
+            bitmap_options.dither_green = header_flags.invader_dither_green == 1;
+            bitmap_options.dither_blue = header_flags.invader_dither_blue == 1;
         }
 
         std::fclose(tag_read);
@@ -439,22 +440,22 @@ int main(int argc, char *argv[]) {
     // If these values weren't set, set them
     #define DEFAULT_VALUE(what, default) if(!what.has_value()) { what = default; }
 
-    DEFAULT_VALUE(format,BitmapFormat::BITMAP_FORMAT_32_BIT_COLOR);
-    DEFAULT_VALUE(bitmap_type,BitmapType::BITMAP_TYPE_2D_TEXTURES);
-    DEFAULT_VALUE(max_mipmap_count,INT16_MAX);
-    DEFAULT_VALUE(sprite_usage,BitmapSpriteUsage::BITMAP_SPRITE_USAGE_BLEND_ADD_SUBTRACT_MAX);
-    DEFAULT_VALUE(sprite_budget,32);
-    DEFAULT_VALUE(sprite_budget_count,0);
-    DEFAULT_VALUE(mipmap_scale_type,ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR);
-    DEFAULT_VALUE(mipmap_fade,0.0F);
-    DEFAULT_VALUE(usage,BitmapUsage::BITMAP_USAGE_DEFAULT);
-    DEFAULT_VALUE(palettize,false);
-    DEFAULT_VALUE(bump_height,0.02F);
-    DEFAULT_VALUE(mipmap_fade,0.0F);
-    DEFAULT_VALUE(dither_alpha,false);
-    DEFAULT_VALUE(dither_red,false);
-    DEFAULT_VALUE(dither_green,false);
-    DEFAULT_VALUE(dither_blue,false);
+    DEFAULT_VALUE(bitmap_options.format,BitmapFormat::BITMAP_FORMAT_32_BIT_COLOR);
+    DEFAULT_VALUE(bitmap_options.bitmap_type,BitmapType::BITMAP_TYPE_2D_TEXTURES);
+    DEFAULT_VALUE(bitmap_options.max_mipmap_count,INT16_MAX);
+    DEFAULT_VALUE(bitmap_options.sprite_usage,BitmapSpriteUsage::BITMAP_SPRITE_USAGE_BLEND_ADD_SUBTRACT_MAX);
+    DEFAULT_VALUE(bitmap_options.sprite_budget,32);
+    DEFAULT_VALUE(bitmap_options.sprite_budget_count,0);
+    DEFAULT_VALUE(bitmap_options.mipmap_scale_type,ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR);
+    DEFAULT_VALUE(bitmap_options.mipmap_fade,0.0F);
+    DEFAULT_VALUE(bitmap_options.usage,BitmapUsage::BITMAP_USAGE_DEFAULT);
+    DEFAULT_VALUE(bitmap_options.palettize,false);
+    DEFAULT_VALUE(bitmap_options.bump_height,0.02F);
+    DEFAULT_VALUE(bitmap_options.mipmap_fade,0.0F);
+    DEFAULT_VALUE(bitmap_options.dither_alpha,false);
+    DEFAULT_VALUE(bitmap_options.dither_red,false);
+    DEFAULT_VALUE(bitmap_options.dither_green,false);
+    DEFAULT_VALUE(bitmap_options.dither_blue,false);
 
     #undef DEFAULT_VALUE
 
@@ -486,7 +487,7 @@ int main(int argc, char *argv[]) {
     }
 
     if(image_pixels == nullptr) {
-        eprintf("Failed to find %s in %s\nValid formats are:\n", bitmap_tag.data(), data);
+        eprintf("Failed to find %s in %s\nValid formats are:\n", bitmap_tag.data(), bitmap_options.data);
         for(auto *format : SUPPORTED_FORMATS) {
             eprintf("    %s\n", format);
         }
@@ -495,16 +496,16 @@ int main(int argc, char *argv[]) {
 
     // Set up sprite parameters
     std::optional<ColorPlateScannerSpriteParameters> sprite_parameters;
-    if(bitmap_type.value() == BitmapType::BITMAP_TYPE_SPRITES) {
+    if(bitmap_options.bitmap_type.value() == BitmapType::BITMAP_TYPE_SPRITES) {
         sprite_parameters = ColorPlateScannerSpriteParameters {};
         auto &p = sprite_parameters.value();
-        p.sprite_budget = sprite_budget.value();
-        p.sprite_budget_count = sprite_budget_count.value();
-        p.sprite_usage = sprite_usage.value();
+        p.sprite_budget = bitmap_options.sprite_budget.value();
+        p.sprite_budget_count = bitmap_options.sprite_budget_count.value();
+        p.sprite_usage = bitmap_options.sprite_usage.value();
     }
 
     // Do it!
-    auto scanned_color_plate = ColorPlateScanner::scan_color_plate(reinterpret_cast<const ColorPlatePixel *>(image_pixels), image_width, image_height, bitmap_type.value(), usage.value(), bump_height.value(), sprite_parameters, max_mipmap_count.value(), mipmap_scale_type.value(), usage == BitmapUsage::BITMAP_USAGE_DETAIL_MAP ? mipmap_fade : std::nullopt, sharpen, blur);
+    auto scanned_color_plate = ColorPlateScanner::scan_color_plate(reinterpret_cast<const ColorPlatePixel *>(image_pixels), image_width, image_height, bitmap_options.bitmap_type.value(), bitmap_options.usage.value(), bitmap_options.bump_height.value(), sprite_parameters, bitmap_options.max_mipmap_count.value(), bitmap_options.mipmap_scale_type.value(), bitmap_options.usage == BitmapUsage::BITMAP_USAGE_DETAIL_MAP ? bitmap_options.mipmap_fade : std::nullopt, bitmap_options.sharpen, bitmap_options.blur);
     std::size_t bitmap_count = scanned_color_plate.bitmaps.size();
 
     // Start building the bitmap tag
@@ -553,7 +554,7 @@ int main(int argc, char *argv[]) {
 
     // Add our bitmap data
     printf("Found %zu bitmap%s:\n", bitmap_count, bitmap_count == 1 ? "" : "s");
-    write_bitmap_data(scanned_color_plate, bitmap_data_pixels, bitmap_data, usage.value(), format.value(), bitmap_type.value(), palettize.value(), dither_alpha.value(), dither_red.value(), dither_green.value(), dither_blue.value());
+    write_bitmap_data(scanned_color_plate, bitmap_data_pixels, bitmap_data, bitmap_options.usage.value(), bitmap_options.format.value(), bitmap_options.bitmap_type.value(), bitmap_options.palettize.value(), bitmap_options.dither_alpha.value(), bitmap_options.dither_red.value(), bitmap_options.dither_green.value(), bitmap_options.dither_blue.value());
     std::printf("Total: %.03f MiB\n", BYTES_TO_MIB(bitmap_data_pixels.size()));
 
     // Add the bitmap pixel data
@@ -596,23 +597,23 @@ int main(int argc, char *argv[]) {
     new_tag_header.bitmap_data.count = bitmap_data.size();
 
     // Set more parameters
-    new_tag_header.type = bitmap_type.value();
-    new_tag_header.usage = usage.value();
-    new_tag_header.bump_height = bump_height.value();
-    new_tag_header.detail_fade_factor = mipmap_fade.value();
-    new_tag_header.format = format.value();
-    new_tag_header.sharpen_amount = sharpen.value_or(0.0F);
-    new_tag_header.blur_filter_size = blur.value_or(0.0F);
-    if(max_mipmap_count.value() >= INT16_MAX) {
+    new_tag_header.type = bitmap_options.bitmap_type.value();
+    new_tag_header.usage = bitmap_options.usage.value();
+    new_tag_header.bump_height = bitmap_options.bump_height.value();
+    new_tag_header.detail_fade_factor = bitmap_options.mipmap_fade.value();
+    new_tag_header.format = bitmap_options.format.value();
+    new_tag_header.sharpen_amount = bitmap_options.sharpen.value_or(0.0F);
+    new_tag_header.blur_filter_size = bitmap_options.blur.value_or(0.0F);
+    if(bitmap_options.max_mipmap_count.value() >= INT16_MAX) {
         new_tag_header.mipmap_count = 0;
     }
     else {
-        new_tag_header.mipmap_count = max_mipmap_count.value() + 1;
+        new_tag_header.mipmap_count = bitmap_options.max_mipmap_count.value() + 1;
     }
 
     BitmapFlags flags = {};
-    flags.disable_height_map_compression = !palettize.value();
-    switch(mipmap_scale_type.value()) {
+    flags.disable_height_map_compression = !bitmap_options.palettize.value();
+    switch(bitmap_options.mipmap_scale_type.value()) {
         case ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_LINEAR:
             break;
         case ScannedColorMipmapType::SCANNED_COLOR_MIPMAP_NEAREST_ALPHA:
@@ -622,16 +623,16 @@ int main(int argc, char *argv[]) {
             flags.invader_nearest_mipmap_alpha_and_color = 1;
             break;
     };
-    flags.invader_dither_alpha = dither_alpha.value();
-    flags.invader_dither_red = dither_red.value();
-    flags.invader_dither_green = dither_green.value();
-    flags.invader_dither_blue = dither_blue.value();
+    flags.invader_dither_alpha = bitmap_options.dither_alpha.value();
+    flags.invader_dither_red = bitmap_options.dither_red.value();
+    flags.invader_dither_green = bitmap_options.dither_green.value();
+    flags.invader_dither_blue = bitmap_options.dither_blue.value();
     new_tag_header.flags = flags;
 
     new_tag_header.sprite_spacing = sprite_parameters.value_or(ColorPlateScannerSpriteParameters{}).sprite_spacing;
-    new_tag_header.sprite_budget_count = sprite_budget_count.value();
-    new_tag_header.sprite_usage = sprite_usage.value();
-    auto &sprite_budget_value = sprite_budget.value();
+    new_tag_header.sprite_budget_count = bitmap_options.sprite_budget_count.value();
+    new_tag_header.sprite_usage = bitmap_options.sprite_usage.value();
+    auto &sprite_budget_value = bitmap_options.sprite_budget.value();
     switch(sprite_budget_value) {
         case 32:
             new_tag_header.sprite_budget_size = BitmapSpriteBudgetSize::BITMAP_SPRITE_BUDGET_SIZE_32X32;

--- a/src/command_line_option.hpp
+++ b/src/command_line_option.hpp
@@ -23,14 +23,6 @@ namespace Invader {
         int argument_count;
     public:
         /**
-         * Argument handler
-         * @param char_name char name of the command line option being handled
-         * @param arguments array of arguments
-         * @param user_data data passed into parse_arguments
-         */
-        using ArgumentHandler = void (*)(char char_name, const std::vector<const char *> &arguments, void *user_data);
-
-        /**
          * Initialize a command line option
          * @param full_name      full name of the command line option
          * @param char_name      char name of the command line option; this will be passed into the argument handler if this is correctly used
@@ -68,11 +60,12 @@ namespace Invader {
          * @param argv            pointer to the first argument
          * @param options         options to use
          * @param error_char_name char_name to use for errors
-         * @param handler         handler function to use
          * @param user_data       user data passed into the arguments
+         * @param handler         handler function to use
          * @return                a vector of all unhandled arguments
          */
-        static std::vector<const char *> parse_arguments(int argc, const char * const *argv, const std::vector<CommandLineOption> &options, char error_char_name, void *user_data, ArgumentHandler handler) {
+        template<typename DataType>
+        static std::vector<const char *> parse_arguments(int argc, const char * const *argv, const std::vector<CommandLineOption> &options, char error_char_name, DataType *user_data, void (*handler)(char char_name, const std::vector<const char *> &arguments, DataType *user_data)) {
             // Hold all unhandled arguments
             std::vector<const char *> unhandled_arguments;
 

--- a/src/command_line_option.hpp
+++ b/src/command_line_option.hpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef INVADER__COMMAND_LINE_OPTION_HPP
+#define INVADER__COMMAND_LINE_OPTION_HPP
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Invader {
+    /**
+     * Header only command line option handler
+     */
+    class CommandLineOption {
+    private:
+        /** Full name of the option */
+        std::string full_name;
+
+        /** Char name of the option */
+        char char_name;
+
+        /** Number of arguments expected */
+        int argument_count;
+    public:
+        /**
+         * Argument handler
+         * @param char_name char name of the command line option being handled
+         * @param arguments array of arguments
+         * @param user_data data passed into parse_arguments
+         */
+        using ArgumentHandler = void (*)(char char_name, const std::vector<const char *> &arguments, void *user_data);
+
+        /**
+         * Initialize a command line option
+         * @param full_name      full name of the command line option
+         * @param char_name      char name of the command line option; this will be passed into the argument handler if this is correctly used
+         * @param argument_count number of arguments expected for the command line option
+         */
+        CommandLineOption(const char *full_name, const char char_name, int argument_count) : full_name(full_name), char_name(char_name), argument_count(argument_count) {}
+
+        /**
+         * Get the full name of the command line option
+         * @return full name
+         */
+        const std::string &get_full_name() const noexcept {
+            return this->full_name;
+        }
+
+        /**
+         * Get the single char name of the command line option
+         * @return char name
+         */
+        char get_char_name() const noexcept {
+            return this->char_name;
+        }
+
+        /**
+         * Get the argument count of the command line option
+         * @return argument count
+         */
+        int get_argument_count() const noexcept {
+            return this->argument_count;
+        }
+
+        /**
+         * Parse the arguments using the given options with the first argument as the path to the program. When enough arguments are found for the given option, the char_name and all options found will be passed to handler. If an error occurs, error_char_name with 0 arguments will be passed.
+         * @param argc            number of arguments
+         * @param argv            pointer to the first argument
+         * @param options         options to use
+         * @param error_char_name char_name to use for errors
+         * @param handler         handler function to use
+         * @param user_data       user data passed into the arguments
+         * @return                a vector of all unhandled arguments
+         */
+        static std::vector<const char *> parse_arguments(int argc, const char * const *argv, const std::vector<CommandLineOption> &options, char error_char_name, void *user_data, ArgumentHandler handler) {
+            // Hold all unhandled arguments
+            std::vector<const char *> unhandled_arguments;
+
+            // Hold the options to be handled
+            std::vector<const CommandLineOption *> currently_handled_options;
+            std::vector<const char *> currently_handled_option_arguments_handled;
+
+            static const char INVALID_OPTION_ERROR[] = "-%s is not a valid option.\n";
+
+            for(int i = 1; i < argc; i++) {
+                // If we don't have any options being worked on, check if this is an option
+                if(currently_handled_options.size() == 0) {
+                    // If it starts with a '-', then we've got something to do
+                    const char *argument = argv[i];
+                    std::size_t argument_length = std::strlen(argument);
+                    if(argument_length >= 1 && argument[0] == '-') {
+                        // It was just a hyphen
+                        if(argument_length == 1) {
+                            std::fprintf(stderr, INVALID_OPTION_ERROR, "");
+                            handler(error_char_name, std::vector<const char *>(), user_data);
+                        }
+
+                        // It's a long option
+                        else if(argument[1] == '-') {
+                            const char *long_option = argument + 2;
+                            bool got_it = false;
+
+                            // Find the option. If we have it, add it.
+                            for(const auto &option : options) {
+                                if(option.get_full_name() == long_option) {
+                                    currently_handled_options.push_back(&option);
+                                    got_it = true;
+                                    break;
+                                }
+                            }
+
+                            // If we didn't get it, then darn
+                            if(!got_it) {
+                                std::fprintf(stderr, INVALID_OPTION_ERROR, argument + 1);
+                                handler(error_char_name, std::vector<const char *>(), user_data);
+                            }
+                        }
+
+                        // It's a short option; possibly multiple of them
+                        else {
+                            for(const char *o = argument + 1; *o; o++) {
+                                // Find the option. If we have it, add it.
+                                bool got_it = false;
+                                for(const auto &option : options) {
+                                    if(option.get_char_name() == *o) {
+                                        currently_handled_options.push_back(&option);
+                                        got_it = true;
+                                        break;
+                                    }
+                                }
+
+                                // If we didn't get it, then darn
+                                if(!got_it) {
+                                    char option_text[2] = { *o, 0 };
+                                    std::fprintf(stderr, INVALID_OPTION_ERROR, option_text);
+                                    handler(error_char_name, std::vector<const char *>(), user_data);
+                                }
+                            }
+                        }
+                    }
+
+                    // Otherwise, it wasn't a handled argument.
+                    else {
+                        unhandled_arguments.push_back(argv[i]);
+                    }
+                }
+
+                // If we do have options being handled, add them to the handled list
+                else {
+                    currently_handled_option_arguments_handled.push_back(argv[i]);
+                }
+
+                // Check to see if we have any options that can be handled now
+                while(currently_handled_options.size() > 0) {
+                    auto &topmost_option = currently_handled_options[0];
+
+                    // If we don't have enough arguments for the option, break and try again later
+                    if(currently_handled_option_arguments_handled.size() < static_cast<std::size_t>(topmost_option->get_argument_count())) {
+                        break;
+                    }
+
+                    // If we do, handle it
+                    handler(topmost_option->get_char_name(), currently_handled_option_arguments_handled, user_data);
+
+                    // Clear the array up
+                    currently_handled_option_arguments_handled.clear();
+
+                    // Remove the first item
+                    currently_handled_options.erase(currently_handled_options.begin());
+                }
+            }
+
+            // If we have unfinished business, do it
+            std::size_t remaining_options = currently_handled_options.size();
+            if(remaining_options != 0) {
+                auto &arg = currently_handled_options[0];
+                int expected_argument_count = arg->get_argument_count();
+                std::fprintf(stderr, "-%c takes %i argument%s, but only %zu %s given.\n", arg->get_char_name(), expected_argument_count, expected_argument_count == 1 ? "" : "s", remaining_options, remaining_options == 1 ? "was" : "were");
+                handler(error_char_name, std::vector<const char *>(), user_data);
+            }
+
+            return unhandled_arguments;
+        }
+    };
+}
+
+#endif

--- a/src/command_line_option.hpp
+++ b/src/command_line_option.hpp
@@ -65,7 +65,7 @@ namespace Invader {
          * @return                a vector of all unhandled arguments
          */
         template<typename DataType>
-        static std::vector<const char *> parse_arguments(int argc, const char * const *argv, const std::vector<CommandLineOption> &options, char error_char_name, DataType *user_data, void (*handler)(char char_name, const std::vector<const char *> &arguments, DataType *user_data)) {
+        static std::vector<const char *> parse_arguments(int argc, const char * const *argv, const std::vector<CommandLineOption> &options, char error_char_name, DataType user_data, void (*handler)(char char_name, const std::vector<const char *> &arguments, DataType user_data)) {
             // Hold all unhandled arguments
             std::vector<const char *> unhandled_arguments;
 

--- a/src/command_line_option.hpp
+++ b/src/command_line_option.hpp
@@ -129,6 +129,16 @@ namespace Invader {
                                     handler(error_char_name, std::vector<const char *>(), user_data);
                                 }
                             }
+
+                            // Make sure only the last option takes arguments
+                            for(std::size_t i = 0; i < currently_handled_options.size() - 1; i++) {
+                                auto *option = currently_handled_options[i];
+                                if(option->argument_count) {
+                                    std::fprintf(stderr, "-%c (passed in \"%s\") takes %i argument%s.\n", option->char_name, argument, option->argument_count, option->argument_count == 1 ? "" : "s");
+                                    std::fprintf(stderr, "Only the last option in an array of options can take arguments.\n");
+                                    handler(error_char_name, std::vector<const char *>(), user_data);
+                                }
+                            }
                         }
                     }
 

--- a/src/command_line_option.hpp
+++ b/src/command_line_option.hpp
@@ -178,7 +178,8 @@ namespace Invader {
             if(remaining_options != 0) {
                 auto &arg = currently_handled_options[0];
                 int expected_argument_count = arg->get_argument_count();
-                std::fprintf(stderr, "-%c takes %i argument%s, but only %zu %s given.\n", arg->get_char_name(), expected_argument_count, expected_argument_count == 1 ? "" : "s", remaining_options, remaining_options == 1 ? "was" : "were");
+                std::size_t remaining_argument_count = currently_handled_option_arguments_handled.size();
+                std::fprintf(stderr, "-%c takes %i argument%s, but only %zu %s given.\n", arg->get_char_name(), expected_argument_count, expected_argument_count == 1 ? "" : "s", remaining_argument_count, remaining_argument_count == 1 ? "was" : "were");
                 handler(error_char_name, std::vector<const char *>(), user_data);
             }
 

--- a/src/dependency/dependency.cpp
+++ b/src/dependency/dependency.cpp
@@ -65,7 +65,7 @@ int main(int argc, char * const *argv) {
     }
 
     // Require a tag
-    char *tag_path_to_find;
+    std::vector<char> tag_path_to_find_data;
     if(remaining_arguments.size() == 0) {
         eprintf("A scenario tag path is required. Use -h for help.\n");
         return EXIT_FAILURE;
@@ -75,8 +75,10 @@ int main(int argc, char * const *argv) {
         return EXIT_FAILURE;
     }
     else {
-        tag_path_to_find = argv[optind];
+        tag_path_to_find_data = std::vector<char>(remaining_arguments[0], remaining_arguments[0] + std::strlen(remaining_arguments[0]));
     }
+
+    char *tag_path_to_find = tag_path_to_find_data.data();
 
     // Get the tag path and extension
     char *c = nullptr;

--- a/src/dependency/dependency.cpp
+++ b/src/dependency/dependency.cpp
@@ -34,7 +34,7 @@ int main(int argc, char * const *argv) {
     auto remaining_arguments = Invader::CommandLineOption::parse_arguments<DependencyOption &>(argc, argv, options, 'h', dependency_options, [](char opt, const auto &arguments, auto &dependency_options) {
         switch(opt) {
             case 't':
-                dependency_options.tags.push_back(optarg);
+                dependency_options.tags.push_back(arguments[0]);
                 break;
             case 'i':
                 INVADER_SHOW_INFO

--- a/src/dependency/dependency.cpp
+++ b/src/dependency/dependency.cpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 #include <string>
-#include <getopt.h>
 #include <filesystem>
 #include <archive.h>
 #include <archive_entry.h>
@@ -12,41 +11,42 @@
 #include "found_tag_dependency.hpp"
 #include "../build/build_workload.hpp"
 #include "../map/map.hpp"
+#include "../command_line_option.hpp"
 
 int main(int argc, char * const *argv) {
-    static struct option options[] = {
-        {"help",  no_argument, 0, 'h'},
-        {"info", no_argument, 0, 'i' },
-        {"tags", required_argument, 0, 't' },
-        {"reverse", no_argument, 0, 'r'},
-        {"recursive", no_argument, 0, 'R'},
-        {0, 0, 0, 0 }
-    };
+    std::vector<Invader::CommandLineOption> options;
+    options.emplace_back("help", 'h', 0);
+    options.emplace_back("info", 'i', 0);
+    options.emplace_back("tags", 't', 1);
+    options.emplace_back("reverse", 'r', 0);
+    options.emplace_back("recursive", 'R', 0);
 
-    int opt;
-    int longindex = 0;
-    bool reverse = false;
-    bool recursive = false;
+    struct DependencyOption {
+        const char *path;
+        bool reverse = false;
+        bool recursive = false;
+        std::vector<std::string> tags;
+        std::string output;
+    } dependency_options;
 
-    // Go through every argument
-    std::vector<std::string> tags;
-    std::string output;
-    while((opt = getopt_long(argc, argv, "t:ihrR", options, &longindex)) != -1) {
+    dependency_options.path = argv[0];
+
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<DependencyOption &>(argc, argv, options, 'h', dependency_options, [](char opt, const auto &arguments, auto &dependency_options) {
         switch(opt) {
             case 't':
-                tags.push_back(optarg);
+                dependency_options.tags.push_back(optarg);
                 break;
             case 'i':
                 INVADER_SHOW_INFO
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
             case 'r':
-                reverse = true;
+                dependency_options.reverse = true;
                 break;
             case 'R':
-                recursive = true;
+                dependency_options.recursive = true;
                 break;
             default:
-                eprintf("Usage: %s [options] <tag.class>\n\n", argv[0]);
+                eprintf("Usage: %s [options] <tag.class>\n\n", dependency_options.path);
                 eprintf("Check dependencies for a tag.\n\n");
                 eprintf("Options:\n");
                 eprintf("  --info,-i                    Show credits, source info, and other info.\n");
@@ -55,23 +55,23 @@ int main(int argc, char * const *argv) {
                 eprintf("  --tags,-t <dir>              Use the specified tags directory. Use multiple\n");
                 eprintf("                               times to add more directories, ordered by\n");
                 eprintf("                               precedence.\n");
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
         }
-    }
+    });
 
     // No tags folder? Use tags in current directory
-    if(tags.size() == 0) {
-        tags.emplace_back("tags");
+    if(dependency_options.tags.size() == 0) {
+        dependency_options.tags.emplace_back("tags");
     }
 
     // Require a tag
     char *tag_path_to_find;
-    if(optind == argc) {
-        eprintf("%s: A scenario tag path is required. Use -h for help.\n", argv[0]);
+    if(remaining_arguments.size() == 0) {
+        eprintf("A scenario tag path is required. Use -h for help.\n");
         return EXIT_FAILURE;
     }
-    else if(optind < argc - 1) {
-        eprintf("Unexpected argument %s\n", argv[optind + 1]);
+    else if(remaining_arguments.size() > 1) {
+        eprintf("Unexpected argument %s\n", remaining_arguments[1]);
         return EXIT_FAILURE;
     }
     else {
@@ -101,7 +101,7 @@ int main(int argc, char * const *argv) {
 
     // Here's an array we can use to hold what we got
     bool success;
-    auto found_tags = Invader::FoundTagDependency::find_dependencies(tag_path_to_find, tag_int_to_find, tags, reverse, recursive, success);
+    auto found_tags = Invader::FoundTagDependency::find_dependencies(tag_path_to_find, tag_int_to_find, dependency_options.tags, dependency_options.reverse, dependency_options.recursive, success);
 
     if(!success) {
         return EXIT_FAILURE;

--- a/src/dependency/dependency.cpp
+++ b/src/dependency/dependency.cpp
@@ -71,7 +71,7 @@ int main(int argc, char * const *argv) {
         return EXIT_FAILURE;
     }
     else if(optind < argc - 1) {
-        eprintf("%s: Unexpected argument %s\n", argv[0], argv[optind + 1]);
+        eprintf("Unexpected argument %s\n", argv[optind + 1]);
         return EXIT_FAILURE;
     }
     else {

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -44,27 +44,26 @@ int main(int argc, char *argv[]) {
     options.emplace_back("info", 'i', 0);
 
     // Do it!
-    auto remaining_arguments = Invader::CommandLineOption::parse_arguments(argc, argv, options, 0, &font_options, [](char opt, const auto &args, auto *options_v) {
-        auto &options = *reinterpret_cast<FontOptions *>(options_v);
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<FontOptions>(argc, argv, options, 0, &font_options, [](char opt, const auto &args, auto *font_options) {
         switch(opt) {
             case 'd':
-                options.data = args[0];
+                font_options->data = args[0];
                 break;
 
             case 't':
-                options.tags = args[0];
+                font_options->tags = args[0];
                 break;
 
             case 's':
-                options.pixel_size = static_cast<int>(std::strtol(args[0], nullptr, 10));
-                if(options.pixel_size <= 0) {
+                font_options->pixel_size = static_cast<int>(std::strtol(args[0], nullptr, 10));
+                if(font_options->pixel_size <= 0) {
                     eprintf("Invalid font size %s\n", args[0]);
                     std::exit(EXIT_FAILURE);
                 }
                 break;
 
             default:
-                eprintf("Usage: %s [options] <font-tag>\n\n", options.path);
+                eprintf("Usage: %s [options] <font-tag>\n\n", font_options->path);
                 eprintf("Create font tags.\n\n");
                 eprintf("Options:\n");
                 eprintf("    --info,-i                  Show license and credits.\n");

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#include <getopt.h>
 #include <cstdio>
 #include <ft2build.h>
 #include <cassert>
@@ -12,6 +11,7 @@
 #include "../tag/hek/class/font.hpp"
 #include "../tag/hek/header.hpp"
 #include "../eprintf.hpp"
+#include "../command_line_option.hpp"
 #include FT_FREETYPE_H
 
 struct RenderedCharacter {
@@ -26,45 +26,45 @@ struct RenderedCharacter {
 };
 
 int main(int argc, char *argv[]) {
-    // Data directory
-    const char *data = "data/";
+    // Options struct
+    struct FontOptions {
+        const char *path;
+        const char *data = "data/";
+        const char *tags = "tags/";
+        int pixel_size = 14;
+    } font_options;
+    font_options.path = argv[0];
 
-    // Tags directory
-    const char *tags = "tags/";
+    // Command line options
+    std::vector<Invader::CommandLineOption> options;
+    options.emplace_back("data", 'd', 1);
+    options.emplace_back("tags", 't', 1);
+    options.emplace_back("font-size", 'i', 1);
+    options.emplace_back("help", 'h', 0);
+    options.emplace_back("info", 'i', 0);
 
-    // Font size
-    int pixel_size = 14;
-
-    int opt = 0, longindex = 0;
-
-    static struct option options[] = {
-        {"data",  required_argument, 0, 'd' },
-        {"tags",  required_argument, 0, 't' },
-        {"help",  no_argument, 0, 'h' },
-        {"help",  no_argument, 0, 'i' },
-        {"font-size",  required_argument, 0, 's' },
-        {0, 0, 0, 0 }
-    };
-    while((opt = getopt_long(argc, argv, "ht:d:s:", options, &longindex)) != -1) {
+    // Do it!
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments(argc, argv, options, 0, &font_options, [](char opt, const auto &args, auto *options_v) {
+        auto &options = *reinterpret_cast<FontOptions *>(options_v);
         switch(opt) {
             case 'd':
-                data = optarg;
+                options.data = args[0];
                 break;
 
             case 't':
-                tags = optarg;
+                options.tags = args[0];
                 break;
 
             case 's':
-                pixel_size = static_cast<int>(std::strtol(optarg, nullptr, 10));
-                if(pixel_size <= 0) {
-                    eprintf("Invalid font size %s\n", optarg);
-                    return EXIT_FAILURE;
+                options.pixel_size = static_cast<int>(std::strtol(args[0], nullptr, 10));
+                if(options.pixel_size <= 0) {
+                    eprintf("Invalid font size %s\n", args[0]);
+                    std::exit(EXIT_FAILURE);
                 }
                 break;
 
             default:
-                eprintf("Usage: %s [options] <font-tag>\n\n", *argv);
+                eprintf("Usage: %s [options] <font-tag>\n\n", options.path);
                 eprintf("Create font tags.\n\n");
                 eprintf("Options:\n");
                 eprintf("    --info,-i                  Show license and credits.\n");
@@ -74,40 +74,36 @@ int main(int argc, char *argv[]) {
                 eprintf("    --tags,-t <path>           Set the tags directory.\n\n");
                 eprintf("Font options:\n");
                 eprintf("    --font-size,-s <px>        Set the font size in pixels.\n\n");
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
         }
-    }
+    });
 
     // Make sure we have the bitmap tag path
-    if(optind != argc - 1) {
-        eprintf("%s: Expected a font tag path. Use -h for help.\n", argv[0]);
+    if(remaining_arguments.size() == 0) {
+        eprintf("Expected a font tag path. Use -h for help.\n");
         return EXIT_FAILURE;
     }
-    char *font_tag = argv[optind];
+    else if(remaining_arguments.size() > 1) {
+        eprintf("Unexpected argument %s. Use -h for help.\n", remaining_arguments[1]);
+        return EXIT_FAILURE;
+    }
+    const char *font_tag = remaining_arguments[0];
 
     // Ensure it's lowercase
-    for(char *c = font_tag; *c; c++) {
+    for(const char *c = font_tag; *c; c++) {
         if(*c >= 'A' && *c <= 'Z') {
             eprintf("Invalid tag path %s. Tag paths must be lowercase.\n", font_tag);
             return EXIT_FAILURE;
         }
     }
 
-    #ifndef _WIN32
-    for(char *c = font_tag; *c; c++) {
-        if(*c == '\\') {
-            *c = '/';
-        }
-    }
-    #endif
-
     // Font tag path
-    std::filesystem::path tags_path(tags);
+    std::filesystem::path tags_path(font_options.tags);
     auto tag_path = tags_path / font_tag;
     auto final_tag_path = tag_path.string() + ".font";
 
     // TTf path
-    std::filesystem::path data_path(data);
+    std::filesystem::path data_path(font_options.data);
     auto ttf_path = data_path / font_tag;
     auto final_ttf_path = ttf_path.string() + ".ttf";
 
@@ -122,8 +118,8 @@ int main(int argc, char *argv[]) {
         eprintf("Failed to open %s.\n", final_ttf_path.data());
         return EXIT_FAILURE;
     }
-    if(FT_Set_Pixel_Sizes(face, pixel_size, pixel_size)) {
-        eprintf("Failed to set pixel size %i.\n", pixel_size);
+    if(FT_Set_Pixel_Sizes(face, font_options.pixel_size, font_options.pixel_size)) {
+        eprintf("Failed to set pixel size %i.\n", font_options.pixel_size);
         return EXIT_FAILURE;
     }
 
@@ -172,15 +168,15 @@ int main(int argc, char *argv[]) {
 
         // Dot
         if(i == 127) {
-            std::vector<unsigned char> data(pixel_size * pixel_size);
-            float radius_inner = pixel_size / 5.0F;
+            std::vector<unsigned char> data(font_options.pixel_size * font_options.pixel_size);
+            float radius_inner = font_options.pixel_size / 5.0F;
             float radius_inner_distance = radius_inner * radius_inner;
-            float center = pixel_size / 2.0F;
+            float center = font_options.pixel_size / 2.0F;
 
             // Make an antialiased circle of fun
-            for(int x = 0; x < pixel_size; x++) {
-                for(int y = 0; y < pixel_size; y++) {
-                    unsigned char &c = data[x * pixel_size + y];
+            for(int x = 0; x < font_options.pixel_size; x++) {
+                for(int y = 0; y < font_options.pixel_size; y++) {
+                    unsigned char &c = data[x * font_options.pixel_size + y];
 
                     // Subpixels
                     for(char sx = -2; sx < 3; sx++) {
@@ -200,8 +196,8 @@ int main(int argc, char *argv[]) {
             // Same as the width of the X character
             int width = characters['X'].x;
             tag_character.character = static_cast<std::uint16_t>(i);
-            tag_character.bitmap_height = pixel_size;
-            tag_character.bitmap_width = pixel_size;
+            tag_character.bitmap_height = font_options.pixel_size;
+            tag_character.bitmap_width = font_options.pixel_size;
             tag_character.character_width = width;
             tag_character.pixels_offset = static_cast<std::uint32_t>(pixels.size());
             tag_character.hardware_character_index = -1;

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -44,26 +44,26 @@ int main(int argc, char *argv[]) {
     options.emplace_back("info", 'i', 0);
 
     // Do it!
-    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<FontOptions>(argc, argv, options, 0, &font_options, [](char opt, const auto &args, auto *font_options) {
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<FontOptions &>(argc, argv, options, 0, font_options, [](char opt, const auto &args, FontOptions &font_options) {
         switch(opt) {
             case 'd':
-                font_options->data = args[0];
+                font_options.data = args[0];
                 break;
 
             case 't':
-                font_options->tags = args[0];
+                font_options.tags = args[0];
                 break;
 
             case 's':
-                font_options->pixel_size = static_cast<int>(std::strtol(args[0], nullptr, 10));
-                if(font_options->pixel_size <= 0) {
+                font_options.pixel_size = static_cast<int>(std::strtol(args[0], nullptr, 10));
+                if(font_options.pixel_size <= 0) {
                     eprintf("Invalid font size %s\n", args[0]);
                     std::exit(EXIT_FAILURE);
                 }
                 break;
 
             default:
-                eprintf("Usage: %s [options] <font-tag>\n\n", font_options->path);
+                eprintf("Usage: %s [options] <font-tag>\n\n", font_options.path);
                 eprintf("Create font tags.\n\n");
                 eprintf("Options:\n");
                 eprintf("    --info,-i                  Show license and credits.\n");

--- a/src/resource/resource.cpp
+++ b/src/resource/resource.cpp
@@ -93,7 +93,7 @@ int main(int argc, const char **argv) {
     });
 
     if(remaining_arguments.size() > 0) {
-        eprintf("Unexpected argument: %s\n", remaining_arguments[0]);
+        eprintf("Unexpected argument %s\n", remaining_arguments[0]);
         return EXIT_FAILURE;
     }
 

--- a/src/string/string.cpp
+++ b/src/string/string.cpp
@@ -149,11 +149,11 @@ int main(int argc, char * const *argv) {
     // Check if there's a string tag
     const char *string_tag;
     if(remaining_arguments.size() == 0) {
-        eprintf("%s: A string tag path is required. Use -h for help.\n", argv[0]);
+        eprintf("A string tag path is required. Use -h for help.\n");
         return EXIT_FAILURE;
     }
     else if(remaining_arguments.size() > 1) {
-        eprintf("%s: Unexpected argument %s\n", argv[0], remaining_arguments[1]);
+        eprintf("Unexpected argument %s\n", remaining_arguments[1]);
         return EXIT_FAILURE;
     }
     else {

--- a/src/string/string.cpp
+++ b/src/string/string.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#include <getopt.h>
 #include <vector>
 #include <string>
 #include <filesystem>
@@ -8,6 +7,7 @@
 #include "../version.hpp"
 #include "../tag/hek/header.hpp"
 #include "../tag/hek/class/string_list.hpp"
+#include "../command_line_option.hpp"
 
 enum Format {
     STRING_LIST_FORMAT_UTF_16,
@@ -91,51 +91,50 @@ static std::vector<std::byte> generate_hud_message_text_tag(const std::string &)
 }
 
 int main(int argc, char * const *argv) {
-    static struct option options[] = {
-        {"help",  no_argument, 0, 'h'},
-        {"info", no_argument, 0, 'i' },
-        {"tags", required_argument, 0, 't' },
-        {"data", required_argument, 0, 'd' },
-        {"format", required_argument, 0, 'f' },
-        {0, 0, 0, 0 }
-    };
+    std::vector<Invader::CommandLineOption> options;
+    options.emplace_back("help", 'h', 0);
+    options.emplace_back("info", 'i', 0);
+    options.emplace_back("tags", 't', 1);
+    options.emplace_back("data", 'd', 1);
+    options.emplace_back("format", 'f', 1);
 
-    int opt;
-    int longindex = 0;
+    struct StringOptions {
+        const char *path;
+        const char *data = "data";
+        const char *tags = "tags";
+        Format format = Format::STRING_LIST_FORMAT_UTF_16;
+        const char *output_extension = ".unicode_string_list";
+    } string_options;
 
-    const char *data = "data";
-    const char *tags = "tags";
-    Format format = Format::STRING_LIST_FORMAT_UTF_16;
-    const char *output_extension = ".unicode_string_list";
+    string_options.path = argv[0];
 
-    // Go through every argument
-    while((opt = getopt_long(argc, argv, "t:d:f:hi", options, &longindex)) != -1) {
+    auto remaining_arguments = Invader::CommandLineOption::parse_arguments<StringOptions &>(argc, argv, options, 'h', string_options, [](char opt, const std::vector<const char *> &arguments, StringOptions &string_options) {
         switch(opt) {
             case 't':
-                tags = optarg;
+                string_options.tags = arguments[0];
                 break;
             case 'i':
                 INVADER_SHOW_INFO
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
             case 'd':
-                data = optarg;
+                string_options.data = arguments[0];
                 break;
             case 'f':
-                if(std::strcmp(optarg, "utf-16") == 0) {
-                    format = Format::STRING_LIST_FORMAT_UTF_16;
-                    output_extension = ".unicode_string_list";
+                if(std::strcmp(arguments[0], "utf-16") == 0) {
+                    string_options.format = Format::STRING_LIST_FORMAT_UTF_16;
+                    string_options.output_extension = ".unicode_string_list";
                 }
-                else if(std::strcmp(optarg, "latin-1") == 0) {
-                    format = Format::STRING_LIST_FORMAT_LATIN1;
-                    output_extension = ".string_list";
+                else if(std::strcmp(arguments[0], "latin-1") == 0) {
+                    string_options.format = Format::STRING_LIST_FORMAT_LATIN1;
+                    string_options.output_extension = ".string_list";
                 }
-                else if(std::strcmp(optarg, "hmt") == 0) {
-                    format = Format::STRING_LIST_FORMAT_HMT;
-                    output_extension = ".hud_message_text";
+                else if(std::strcmp(arguments[0], "hmt") == 0) {
+                    string_options.format = Format::STRING_LIST_FORMAT_HMT;
+                    string_options.output_extension = ".hud_message_text";
                 }
                 break;
             default:
-                eprintf("Usage: %s [options] <tag>\n\n", argv[0]);
+                eprintf("Usage: %s [options] <tag>\n\n", arguments[0]);
                 eprintf("Generate string list tags.\n\n");
                 eprintf("Options:\n");
                 eprintf("  --info,-i                    Show credits, source info, and other info.\n");
@@ -143,22 +142,22 @@ int main(int argc, char * const *argv) {
                 eprintf("                               or latin-1. Default: utf-16\n");
                 eprintf("  --data,-d <dir>              Use the specified data directory.\n");
                 eprintf("  --tags,-t <dir>              Use the specified tags directory.\n");
-                return EXIT_FAILURE;
+                std::exit(EXIT_FAILURE);
         }
-    }
+    });
 
     // Check if there's a string tag
     const char *string_tag;
-    if(optind == argc) {
+    if(remaining_arguments.size() == 0) {
         eprintf("%s: A string tag path is required. Use -h for help.\n", argv[0]);
         return EXIT_FAILURE;
     }
-    else if(optind < argc - 1) {
-        eprintf("%s: Unexpected argument %s\n", argv[0], argv[optind + 1]);
+    else if(remaining_arguments.size() > 1) {
+        eprintf("%s: Unexpected argument %s\n", argv[0], remaining_arguments[1]);
         return EXIT_FAILURE;
     }
     else {
-        string_tag = argv[optind];
+        string_tag = remaining_arguments[0];
     }
 
     // Ensure it's lowercase
@@ -169,11 +168,11 @@ int main(int argc, char * const *argv) {
         }
     }
 
-    std::filesystem::path tags_path(tags);
-    std::filesystem::path data_path(data);
+    std::filesystem::path tags_path(string_options.tags);
+    std::filesystem::path data_path(string_options.data);
 
-    auto input_path = (data_path / string_tag).string() + (format == Format::STRING_LIST_FORMAT_HMT ? ".hmt" : ".txt");
-    auto output_path = (tags_path / string_tag).string() + output_extension;
+    auto input_path = (data_path / string_tag).string() + (string_options.format == Format::STRING_LIST_FORMAT_HMT ? ".hmt" : ".txt");
+    auto output_path = (tags_path / string_tag).string() + string_options.output_extension;
 
     // Open a file
     std::FILE *f = std::fopen(input_path.data(), "rb");
@@ -218,7 +217,7 @@ int main(int argc, char * const *argv) {
 
     // Generate the data
     std::vector<std::byte> final_data;
-    switch(format) {
+    switch(string_options.format) {
         case STRING_LIST_FORMAT_UTF_16:
             final_data = generate_string_list_tag<char16_t, Invader::HEK::TagClassInt::TAG_CLASS_UNICODE_STRING_LIST>(text);
             break;


### PR DESCRIPTION
This removes the getopt.h dependency and replaces it with my own argument parser. getopt.h is not guaranteed to be available on all compilers, so it may be a good idea to do this.

This just uses the standard library and templates in a header file.