### PR TITLE
Have tools use the new parser

### DIFF
--- a/include/invader/bitmap/bitmap_data_writer.hpp
+++ b/include/invader/bitmap/bitmap_data_writer.hpp
@@ -4,11 +4,12 @@
 #define INVADER__BITMAP__BITMAP_DATA_WRITER_HPP
 
 #include "color_plate_scanner.hpp"
+#include "../tag/parser/parser.hpp"
 
 namespace Invader {
     using BitmapFormat = HEK::BitmapFormat;
 
-    void write_bitmap_data(const GeneratedBitmapData &scanned_color_plate, std::vector<std::byte> &bitmap_data_pixels, std::vector<HEK::BitmapData<HEK::BigEndian>> &bitmap_data, BitmapUsage usage, BitmapFormat format, BitmapType bitmap_type, bool palettize, bool dither_alpha, bool dither_red, bool dither_green, bool dither_blue);
+    void write_bitmap_data(const GeneratedBitmapData &scanned_color_plate, std::vector<std::byte> &bitmap_data_pixels, std::vector<Parser::BitmapData> &bitmap_data, BitmapUsage usage, BitmapFormat format, BitmapType bitmap_type, bool palettize, bool dither_alpha, bool dither_red, bool dither_green, bool dither_blue);
 }
 
 #endif

--- a/include/invader/version.hpp
+++ b/include/invader/version.hpp
@@ -19,4 +19,10 @@ namespace Invader {
     const char *full_version();
 }
 
+#ifdef INVADER_EXTRACT_HIDDEN_VALUES
+#define EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES eprintf_error("Error: Invader was compiled with INVADER_EXTRACT_HIDDEN_VALUES."); eprintf_error("This program cannot be used."); std::exit(EXIT_FAILURE);
+#else
+#define EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+#endif
+
 #endif

--- a/src/bitmap/bitmap.cpp
+++ b/src/bitmap/bitmap.cpp
@@ -36,6 +36,8 @@ static const char *SUPPORTED_FORMATS[] = {
 static_assert(sizeof(SUPPORTED_FORMATS) / sizeof(*SUPPORTED_FORMATS) == SUPPORTED_FORMATS_INT_COUNT);
 
 int main(int argc, char *argv[]) {
+    EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+
     using namespace Invader::HEK;
     using namespace Invader;
 

--- a/src/bitmap/bitmap.cpp
+++ b/src/bitmap/bitmap.cpp
@@ -648,15 +648,14 @@ int main(int argc, char *argv[]) {
     // Write it all
     try {
         if(!std::filesystem::exists(tag_path.parent_path())) {
-        }
             std::filesystem::create_directories(tag_path.parent_path());
-    catch(std::exception &e) {
+        }
     }
+    catch(std::exception &e) {
         eprintf_error("Error: Failed to create a directory: %s\n", e.what());
         return EXIT_FAILURE;
     }
     if(!File::save_file(final_path.c_str(), bitmap_tag_data.generate_hek_tag_data(TagClassInt::TAG_CLASS_BITMAP, true))) {
-    
         eprintf_error("Error: Failed to write to %s.", final_path.c_str());
         return EXIT_FAILURE;
     }

--- a/src/bitmap/bitmap.cpp
+++ b/src/bitmap/bitmap.cpp
@@ -514,7 +514,7 @@ int main(int argc, char *argv[]) {
     std::size_t bitmap_count = scanned_color_plate.bitmaps.size();
 
     // Start building the bitmap tag
-    Parser::Bitmap bitmap_tag_data;
+    Parser::Bitmap bitmap_tag_data = {};
 
     // Compress the original input blob
     {

--- a/src/bitmap/bitmap_data_writer.cpp
+++ b/src/bitmap/bitmap_data_writer.cpp
@@ -8,7 +8,7 @@
 #include <invader/printf.hpp>
 
 namespace Invader {
-    void write_bitmap_data(const GeneratedBitmapData &scanned_color_plate, std::vector<std::byte> &bitmap_data_pixels, std::vector<HEK::BitmapData<HEK::BigEndian>> &bitmap_data, BitmapUsage usage, BitmapFormat format, BitmapType bitmap_type, bool palettize, bool dither_alpha, bool dither_red, bool dither_green, bool dither_blue) {
+    void write_bitmap_data(const GeneratedBitmapData &scanned_color_plate, std::vector<std::byte> &bitmap_data_pixels, std::vector<Parser::BitmapData> &bitmap_data, BitmapUsage usage, BitmapFormat format, BitmapType bitmap_type, bool palettize, bool dither_alpha, bool dither_red, bool dither_green, bool dither_blue) {
         using namespace Invader::HEK;
 
         bool dithering = dither_alpha || dither_red || dither_green || dither_blue;
@@ -97,7 +97,7 @@ namespace Invader {
             bool compressed = (format == BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_COLOR_KEY_TRANSPARENCY || format == BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_EXPLICIT_ALPHA || format == BitmapFormat::BITMAP_FORMAT_COMPRESSED_WITH_INTERPOLATED_ALPHA);
 
             // If the bitmap length or height isn't divisible by 4, use 32-bit color
-            if(compressed && ((bitmap.height.read() % 4) != 0 || (bitmap.width.read() % 4) != 0)) {
+            if(compressed && ((bitmap.height % 4) != 0 || (bitmap.width % 4) != 0)) {
                 format = BitmapFormat::BITMAP_FORMAT_32_BIT_COLOR;
                 compressed = false;
             }
@@ -244,7 +244,7 @@ namespace Invader {
             }
 
             // Depending on the format, do something
-            auto bitmap_format = bitmap.format.read();
+            auto bitmap_format = bitmap.format;
             switch(bitmap_format) {
                 // If it's 32-bit, this is a no-op.
                 case BitmapDataFormat::BITMAP_DATA_FORMAT_A8R8G8B8:

--- a/src/bitmap/bitmap_data_writer.cpp
+++ b/src/bitmap/bitmap_data_writer.cpp
@@ -16,7 +16,7 @@ namespace Invader {
         auto bitmap_count = scanned_color_plate.bitmaps.size();
         for(std::size_t i = 0; i < bitmap_count; i++) {
             // Write all of the fields here
-            auto &bitmap = bitmap_data[i];
+            auto &bitmap = bitmap_data.emplace_back();
             auto &bitmap_color_plate = scanned_color_plate.bitmaps[i];
             bitmap.bitmap_class = TagClassInt::TAG_CLASS_BITMAP;
             bitmap.width = bitmap_color_plate.width;

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -278,16 +278,16 @@ int main(int argc, char *argv[]) {
 
     // Write
     try {
-            std::filesystem::create_directories(tag_path.parent_path());
         if(!std::filesystem::exists(tag_path.parent_path())) {
+            std::filesystem::create_directories(tag_path.parent_path());
         }
     }
-        return EXIT_FAILURE;
-        eprintf_error("Error: Failed to create a directory: %s\n", e.what());
     catch(std::exception &e) {
+        eprintf_error("Error: Failed to create a directory: %s\n", e.what());
+        return EXIT_FAILURE;
     }
 
-    if(!Invader::File::save_file(final_tag_path.c_str(), final_font)) {
+    if(!Invader::File::save_file(final_tag_path.c_str(), font.generate_hek_tag_data(Invader::TagClassInt::TAG_CLASS_FONT, true))) {
         eprintf_error("Failed to save %s.", final_tag_path.c_str());
         return EXIT_FAILURE;
     }

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -42,6 +42,8 @@ enum FontExtension {
 static_assert(FONT_EXTENSION_COUNT == sizeof(FONT_EXTENSION_STR) / sizeof(*FONT_EXTENSION_STR));
 
 int main(int argc, char *argv[]) {
+    EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+
     // Options struct
     struct FontOptions {
         const char *data = "data/";

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -196,7 +196,7 @@ int main(int argc, char *argv[]) {
     FT_Done_FreeType(library);
 
     // Create
-    Invader::Parser::Font font;
+    Invader::Parser::Font font= {};
     std::vector<Invader::HEK::FontCharacter<Invader::HEK::BigEndian>> tag_characters;
     auto &pixels = font.pixels;
 

--- a/src/invader.cmake
+++ b/src/invader.cmake
@@ -142,9 +142,7 @@ set_source_files_properties(src/version.cpp
 
 # Set a constant if we're extracting hidden values
 if(${INVADER_EXTRACT_HIDDEN_VALUES})
-    set_source_files_properties(src/tag/hek/header.cpp
-        PROPERTIES COMPILE_DEFINITIONS "INVADER_EXTRACT_HIDDEN_VALUES"
-    )
+    add_definitions(-DINVADER_EXTRACT_HIDDEN_VALUES)
 endif()
 
 # Remove warnings from this

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -10,6 +10,8 @@
 #include <invader/file/file.hpp>
 
 int main(int argc, const char **argv) {
+    EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+
     using namespace Invader;
     //using namespace Invader::HEK;
 
@@ -160,9 +162,6 @@ int main(int argc, const char **argv) {
         return EXIT_FAILURE;
     }
 
-    bool error;
-    std::string error_message;
-    auto new_s = Compiler::decompile_scenario(s, error, error_message);
-
+    auto new_s = Compiler::decompile_scenario(s);
     oprintf("%s\n\n", Tokenizer::detokenize(ScriptTree::decompile_script_tree(new_s)).c_str());
 }

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -12,6 +12,8 @@
 #include <samplerate.h>
 
 int main(int argc, const char **argv) {
+    EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+
     using namespace Invader;
     using namespace Invader::HEK;
     static constexpr std::size_t SPLIT_BUFFER_SIZE = 0x38E00;

--- a/src/string/string.cpp
+++ b/src/string/string.cpp
@@ -18,6 +18,8 @@ enum Format {
 };
 
 template <typename T, typename G, Invader::TagClassInt C> static std::vector<std::byte> generate_string_list_tag(const std::string &input_string) {
+    EXIT_IF_INVADER_EXTRACT_HIDDEN_VALUES
+
     using namespace Invader::HEK;
 
     // Make the file header
@@ -225,7 +227,7 @@ int main(int argc, char * const *argv) {
 
     // Write it all
     std::filesystem::path tag_path(output_path);
-    
+
     // Create missing directories if needed
     try {
         if(!std::filesystem::exists(tag_path.parent_path())) {
@@ -237,18 +239,10 @@ int main(int argc, char * const *argv) {
         return EXIT_FAILURE;
     }
 
-    std::FILE *tag_write = std::fopen(output_path.c_str(), "wb");
-    if(!tag_write) {
-        eprintf_error("Error: Failed to open %s for writing.\n", output_path.c_str());;
-        return EXIT_FAILURE;
-    }
-
-    if(std::fwrite(final_data.data(), final_data.size(), 1, tag_write) != 1) {
+    if(!Invader::File::save_file(output_path.c_str(), final_data)) {
         eprintf_error("Error: Failed to write to %s.\n", output_path.c_str());
-        std::fclose(tag_write);
         return EXIT_FAILURE;
     }
 
-    std::fclose(tag_write);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This answers issue https://github.com/Kavawuvi/invader/issues/64 and retrofits the older tools with the newer parser. This is less error-prone and also makes the CRC32 calculated in the tag header.

This will need some further testing before I'm confident that these don't break anything.