### PR TITLE
Update model.cpp - fix build-error for missing INT_MAX

### DIFF
--- a/src/tag/parser/compile/model.cpp
+++ b/src/tag/parser/compile/model.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+#include <climits>
 #include <invader/build/build_workload.hpp>
 #include <invader/tag/parser/parser.hpp>
 #include <invader/tag/parser/compile/model.hpp>


### PR DESCRIPTION
On EndeavourOS / Arch the aur-builds of the `invader` and `invader-git` packages fail, complaining about a missing `INT_MAX` definition in the `model.cpp` file. After adding the include, the build succeedes.